### PR TITLE
Fix golint errors for commands.go

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -82,10 +82,7 @@ func (v Vehicle) TriggerHomelink() error {
 	body, _ := json.Marshal(autoParkRequest)
 
 	_, err := sendCommand(apiUrl, body)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 // Wakes up the vehicle when it is powered off

--- a/commands.go
+++ b/commands.go
@@ -82,7 +82,9 @@ func (v Vehicle) TriggerHomelink() error {
 	body, _ := json.Marshal(autoParkRequest)
 
 	_, err := sendCommand(apiUrl, body)
-	return err
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/commands_test.go
+++ b/commands_test.go
@@ -187,6 +187,7 @@ func TestCommandsSpec(t *testing.T) {
 		So(err, ShouldBeNil)
 		vehicle := vehicles[0]
 		err = vehicle.Start("foo")
+		So(err, ShouldBeNil)
 	})
 
 	Convey("Should move the Pano Roof around", t, func() {


### PR DESCRIPTION
I was working locally on doing some testing with this library and ran into a couple minor golint errors.
- Unreachable code within Vehicle.TriggerHomelink
- Unused `err` in commands_test.go
