### PR TITLE
Allow API token re-use when initializing the client

### DIFF
--- a/states.go
+++ b/states.go
@@ -77,7 +77,7 @@ type DriveState struct {
 	Latitude   float64     `json:"latitude"`
 	Longitude  float64     `json:"longitude"`
 	Heading    int         `json:"heading"`
-	GpsAsOf    int         `json:"gps_as_of"`
+	GpsAsOf    int64       `json:"gps_as_of"`
 }
 
 // Contains the current GUI settings of the vehicle


### PR DESCRIPTION
I needed a way to avoid re-authorizing and obtaining a new token frequently, and also needed a way to know when a token was expired so I could re-authorize. Additionally, I changed a few JSON time values to int64, so that casting these values isn't necessary when using Go's time functions.