### PR TITLE
Allow custom http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -18,7 +18,7 @@ type Auth struct {
 	Password     string `json:"password"`
 	URL          string
 	StreamingURL string
-	HTTPClient   HTTPDoer
+	HTTPClient   HTTPDoer `json:"-"`
 }
 
 // The token and related elements returned after a successful auth


### PR DESCRIPTION
Allow setting logger on client. I've simply added the client interface to the auth struct. No new methods.

All tests are passing:

```
--- PASS: TestVehiclesSpec (0.00s)
PASS
ok      github.com/jsgoecke/tesla       0.277s
?       github.com/jsgoecke/tesla/examples      [no test files]
```

Replaces https://github.com/jsgoecke/tesla/pull/21